### PR TITLE
Always use player UUID in stat file path

### DIFF
--- a/src/main/java/pw/kaboom/papermixins/mixin/disable_username_validation/PlayerListMixin.java
+++ b/src/main/java/pw/kaboom/papermixins/mixin/disable_username_validation/PlayerListMixin.java
@@ -1,0 +1,28 @@
+package pw.kaboom.papermixins.mixin.disable_username_validation;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.server.players.PlayerList;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.io.File;
+import java.util.UUID;
+
+@Mixin(PlayerList.class)
+public abstract class PlayerListMixin {
+    @WrapOperation(
+            method = "getPlayerStats(Ljava/util/UUID;Ljava/lang/String;)Lnet/minecraft/stats/ServerStatsCounter;",
+            at = @At(
+                    value = "NEW",
+                    target = "(Ljava/io/File;Ljava/lang/String;)Ljava/io/File;"
+            )
+    )
+    private File getPlayerStats$newFile(final File parent,
+                                        final String child,
+                                        final Operation<File> original,
+                                        @Local(argsOnly = true) final UUID id) {
+        return original.call(parent, id + ".json");
+    }
+}

--- a/src/main/java/pw/kaboom/papermixins/mixin/disable_username_validation/PlayerListMixin.java
+++ b/src/main/java/pw/kaboom/papermixins/mixin/disable_username_validation/PlayerListMixin.java
@@ -14,14 +14,8 @@ import java.util.UUID;
 public abstract class PlayerListMixin {
     @WrapOperation(
             method = "getPlayerStats(Ljava/util/UUID;Ljava/lang/String;)Lnet/minecraft/stats/ServerStatsCounter;",
-            at = @At(
-                    value = "NEW",
-                    target = "(Ljava/io/File;Ljava/lang/String;)Ljava/io/File;"
-            )
-    )
-    private File getPlayerStats$newFile(final File parent,
-                                        final String child,
-                                        final Operation<File> original,
+            at = @At(value = "NEW", target = "(Ljava/io/File;Ljava/lang/String;)Ljava/io/File;"))
+    private File getPlayerStats$newFile(final File parent, final String child, final Operation<File> original,
                                         @Local(argsOnly = true) final UUID id) {
         return original.call(parent, id + ".json");
     }

--- a/src/main/resources/kaboom-paper-mixins.mixins.json
+++ b/src/main/resources/kaboom-paper-mixins.mixins.json
@@ -5,6 +5,7 @@
   "required": true,
   "mixins": [
     "disable_username_validation.CraftPlayerProfileMixin",
+    "disable_username_validation.PlayerListMixin",
     "execute_vanilla_only.BukkitBrigForwardingMapMixin",
     "execute_vanilla_only.CommandsMixin",
     "execute_vanilla_only.ExecuteCommandMixin"


### PR DESCRIPTION
Fixes an issue on Windows systems where players joining with an NTFS illegal character in their name would cause an Internal server error and not be able to connect, while being able to connect to Kaboom clones on other operating systems.

I put this in the disable_username_validation package because with username validation this issue cannot occur.