### PR TITLE
Only schedule ticks for command blocks when their command is updated (and they are repeating automatic command blocks) or when they are powered

### DIFF
--- a/src/main/java/pw/kaboom/papermixins/mixin/perf/command_block_optimization/CommandBlockEntityBaseCommandBlockImplMixin.java
+++ b/src/main/java/pw/kaboom/papermixins/mixin/perf/command_block_optimization/CommandBlockEntityBaseCommandBlockImplMixin.java
@@ -1,0 +1,28 @@
+package pw.kaboom.papermixins.mixin.perf.command_block_optimization;
+
+import net.minecraft.util.StringUtil;
+import net.minecraft.world.level.block.entity.CommandBlockEntity;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import pw.kaboom.papermixins.mixin.perf.command_block_optimization.accessor.CommandBlockEntityAccessor;
+
+@Mixin(targets = "net.minecraft.world.level.block.entity.CommandBlockEntity$1")
+public class CommandBlockEntityBaseCommandBlockImplMixin {
+    @Shadow
+    @Final
+    CommandBlockEntity this$0;
+
+    @Inject(method = "setCommand", at = @At("TAIL"))
+    private void onSetCommand(final String command, final CallbackInfo ci) {
+        if (
+                StringUtil.isNullOrEmpty(command)
+                        || (!this$0.isAutomatic() || this$0.getMode() != CommandBlockEntity.Mode.AUTO)
+        )
+            return;
+        ((CommandBlockEntityAccessor) this$0).invokeScheduleTick();
+    }
+}

--- a/src/main/java/pw/kaboom/papermixins/mixin/perf/command_block_optimization/CommandBlockEntityBaseCommandBlockImplMixin.java
+++ b/src/main/java/pw/kaboom/papermixins/mixin/perf/command_block_optimization/CommandBlockEntityBaseCommandBlockImplMixin.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import pw.kaboom.papermixins.mixin.perf.command_block_optimization.accessor.CommandBlockEntityAccessor;
 
 @Mixin(targets = "net.minecraft.world.level.block.entity.CommandBlockEntity$1")
-public class CommandBlockEntityBaseCommandBlockImplMixin {
+public abstract class CommandBlockEntityBaseCommandBlockImplMixin {
     @Shadow
     @Final
     CommandBlockEntity this$0;

--- a/src/main/java/pw/kaboom/papermixins/mixin/perf/command_block_optimization/CommandBlockEntityBaseCommandBlockImplMixin.java
+++ b/src/main/java/pw/kaboom/papermixins/mixin/perf/command_block_optimization/CommandBlockEntityBaseCommandBlockImplMixin.java
@@ -18,11 +18,10 @@ public abstract class CommandBlockEntityBaseCommandBlockImplMixin {
 
     @Inject(method = "setCommand", at = @At("TAIL"))
     private void onSetCommand(final String command, final CallbackInfo ci) {
-        if (
-                StringUtil.isNullOrEmpty(command)
-                        || (!this$0.isAutomatic() || this$0.getMode() != CommandBlockEntity.Mode.AUTO)
-        )
+        if (StringUtil.isNullOrEmpty(command)
+                || (!this$0.isAutomatic() || this$0.getMode() != CommandBlockEntity.Mode.AUTO)) {
             return;
+        }
         ((CommandBlockEntityAccessor) this$0).invokeScheduleTick();
     }
 }

--- a/src/main/java/pw/kaboom/papermixins/mixin/perf/command_block_optimization/CommandBlockMixin.java
+++ b/src/main/java/pw/kaboom/papermixins/mixin/perf/command_block_optimization/CommandBlockMixin.java
@@ -1,0 +1,23 @@
+package pw.kaboom.papermixins.mixin.perf.command_block_optimization;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.CommandBlock;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(CommandBlock.class)
+public abstract class CommandBlockMixin {
+    @WrapOperation(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;" +
+            "scheduleTick(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Block;I)V"))
+    private void tick$scheduleTick(final ServerLevel instance, final BlockPos blockPos,
+                                   final Block block, final int delay,
+                                   final Operation<Void> original) {
+        // Don't schedule the tick here
+    }
+}

--- a/src/main/java/pw/kaboom/papermixins/mixin/perf/command_block_optimization/accessor/CommandBlockEntityAccessor.java
+++ b/src/main/java/pw/kaboom/papermixins/mixin/perf/command_block_optimization/accessor/CommandBlockEntityAccessor.java
@@ -1,0 +1,11 @@
+package pw.kaboom.papermixins.mixin.perf.command_block_optimization.accessor;
+
+import net.minecraft.world.level.block.entity.CommandBlockEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(CommandBlockEntity.class)
+public interface CommandBlockEntityAccessor {
+  @Invoker
+  void invokeScheduleTick();
+}

--- a/src/main/resources/kaboom-paper-mixins.mixins.json
+++ b/src/main/resources/kaboom-paper-mixins.mixins.json
@@ -10,7 +10,10 @@
     "feat.disable_username_validation.PlayerListMixin",
     "feat.execute_vanilla_only.BukkitBrigForwardingMapMixin",
     "feat.execute_vanilla_only.CommandsMixin",
-    "feat.execute_vanilla_only.ExecuteCommandMixin"
+    "feat.execute_vanilla_only.ExecuteCommandMixin",
+    "perf.command_block_optimization.CommandBlockEntityBaseCommandBlockImplMixin",
+    "perf.command_block_optimization.CommandBlockMixin",
+    "perf.command_block_optimization.accessor.CommandBlockEntityAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This provides orders of magnitude more server performance when a large amount of automatic repeating command blocks are loaded