### PR TITLE
perf: assume plugins don't need tile entity snapshots unless they specify that they do

### DIFF
--- a/src/main/java/pw/kaboom/papermixins/mixin/perf/block_state_no_copy/CraftChunkMixin.java
+++ b/src/main/java/pw/kaboom/papermixins/mixin/perf/block_state_no_copy/CraftChunkMixin.java
@@ -1,0 +1,20 @@
+package pw.kaboom.papermixins.mixin.perf.block_state_no_copy;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.bukkit.block.BlockState;
+import org.bukkit.craftbukkit.CraftChunk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(CraftChunk.class)
+public abstract class CraftChunkMixin {
+    @WrapOperation(
+            method = "getTileEntities()[Lorg/bukkit/block/BlockState;",
+            at = @At(value = "INVOKE", target = "Lorg/bukkit/craftbukkit/CraftChunk;getTileEntities(Z)[Lorg/bukkit/block/BlockState;"))
+    private BlockState[] getTileEntities$overload(final CraftChunk instance,
+                                                  final boolean snapshot,
+                                                  final Operation<BlockState[]> original) {
+        return original.call(instance, false);
+    }
+}

--- a/src/main/resources/kaboom-paper-mixins.mixins.json
+++ b/src/main/resources/kaboom-paper-mixins.mixins.json
@@ -12,6 +12,7 @@
     "feat.execute_vanilla_only.BukkitBrigForwardingMapMixin",
     "feat.execute_vanilla_only.CommandsMixin",
     "feat.execute_vanilla_only.ExecuteCommandMixin",
+    "perf.block_state_no_copy.CraftChunkMixin",
     "perf.command_block_optimization.CommandBlockEntityBaseCommandBlockImplMixin",
     "perf.command_block_optimization.CommandBlockMixin",
     "perf.command_block_optimization.accessor.CommandBlockEntityAccessor"


### PR DESCRIPTION
Should fix lag caused by /gc