### PR TITLE
fix: don't allow command block commands to be cloned/filled

### DIFF
--- a/src/main/java/pw/kaboom/papermixins/mixin/fix/command_block_restrictions/CloneCommandsMixin.java
+++ b/src/main/java/pw/kaboom/papermixins/mixin/fix/command_block_restrictions/CloneCommandsMixin.java
@@ -1,0 +1,26 @@
+package pw.kaboom.papermixins.mixin.fix.command_block_restrictions;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.commands.CloneCommands;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.CommandBlockEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(CloneCommands.class)
+public abstract class CloneCommandsMixin {
+    @ModifyExpressionValue(method = "clone",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/entity/BlockEntity;saveCustomOnly" +
+                    "(Lnet/minecraft/core/HolderLookup$Provider;)Lnet/minecraft/nbt/CompoundTag;"))
+    private static CompoundTag clone$saveCustomOnly(final CompoundTag original,
+                                                    final @Local(ordinal = 0) BlockEntity blockEntity) {
+        if (!(blockEntity instanceof CommandBlockEntity)) {
+            return original;
+        }
+
+        original.remove("Command");
+        return original;
+    }
+}

--- a/src/main/java/pw/kaboom/papermixins/mixin/fix/command_block_restrictions/FillCommandMixin.java
+++ b/src/main/java/pw/kaboom/papermixins/mixin/fix/command_block_restrictions/FillCommandMixin.java
@@ -1,0 +1,24 @@
+package pw.kaboom.papermixins.mixin.fix.command_block_restrictions;
+
+import net.minecraft.commands.arguments.blocks.BlockInput;
+import net.minecraft.server.commands.FillCommand;
+import net.minecraft.world.level.block.CommandBlock;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(FillCommand.class)
+public abstract class FillCommandMixin {
+    @ModifyVariable(method = "fillBlocks", at = @At("HEAD"), argsOnly = true)
+    private static BlockInput fillBlocks(final BlockInput block) {
+        // Only modify command blocks with NBT data
+        if (block.tag == null ||
+                !(block.getState().getBlock() instanceof CommandBlock)) {
+            return block;
+        }
+
+        // We remove Command instead of auto here, else people can just power the command blocks with another /fill.
+        block.tag.remove("Command");
+        return block;
+    }
+}

--- a/src/main/java/pw/kaboom/papermixins/mixin/fix/command_block_restrictions/StructureTemplateMixin.java
+++ b/src/main/java/pw/kaboom/papermixins/mixin/fix/command_block_restrictions/StructureTemplateMixin.java
@@ -1,0 +1,26 @@
+package pw.kaboom.papermixins.mixin.fix.command_block_restrictions;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.CommandBlockEntity;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(StructureTemplate.class)
+public abstract class StructureTemplateMixin {
+    @ModifyExpressionValue(method = "fillFromWorld",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/entity/BlockEntity;" +
+                    "saveWithId(Lnet/minecraft/core/HolderLookup$Provider;)Lnet/minecraft/nbt/CompoundTag;"))
+    private CompoundTag fillFromWorld$saveWithId(final CompoundTag original,
+                                                 final @Local(ordinal = 0) BlockEntity blockEntity) {
+        if (!(blockEntity instanceof CommandBlockEntity)) {
+            return original;
+        }
+
+        original.remove("Command");
+        return original;
+    }
+}

--- a/src/main/resources/kaboom-paper-mixins.mixins.json
+++ b/src/main/resources/kaboom-paper-mixins.mixins.json
@@ -19,6 +19,8 @@
     "feat.plugin_mixins.LibraryLoaderMixin",
     "feat.plugin_mixins.PluginClassLoaderMixin",
     "feat.plugin_mixins.SpigotPluginProviderMixin",
+    "fix.command_block_restrictions.CloneCommandsMixin",
+    "fix.command_block_restrictions.FillCommandMixin",
     "fix.exploit.beehive_uncapped_bees.BeehiveBlockEntityOccupantMixin",
     "perf.command_block_optimization.CommandBlockEntityBaseCommandBlockImplMixin",
     "perf.command_block_optimization.CommandBlockMixin",

--- a/src/main/resources/kaboom-paper-mixins.mixins.json
+++ b/src/main/resources/kaboom-paper-mixins.mixins.json
@@ -21,6 +21,7 @@
     "feat.plugin_mixins.SpigotPluginProviderMixin",
     "fix.command_block_restrictions.CloneCommandsMixin",
     "fix.command_block_restrictions.FillCommandMixin",
+    "fix.command_block_restrictions.StructureTemplateMixin",
     "fix.exploit.beehive_uncapped_bees.BeehiveBlockEntityOccupantMixin",
     "perf.command_block_optimization.CommandBlockEntityBaseCommandBlockImplMixin",
     "perf.command_block_optimization.CommandBlockMixin",


### PR DESCRIPTION
Closes https://github.com/kaboomserver/extras/pull/362 (which closes https://github.com/kaboomserver/server/issues/140)