### PR TITLE
fix: limit written book content pages to 100

### DIFF
--- a/src/main/java/pw/kaboom/papermixins/mixin/fix/exploit/page_amount_exploit/WrittenBookContentMixin.java
+++ b/src/main/java/pw/kaboom/papermixins/mixin/fix/exploit/page_amount_exploit/WrittenBookContentMixin.java
@@ -1,0 +1,38 @@
+package pw.kaboom.papermixins.mixin.fix.exploit.page_amount_exploit;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.serialization.Codec;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.item.component.WrittenBookContent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.List;
+
+@Mixin(WrittenBookContent.class)
+public abstract class WrittenBookContentMixin {
+    @Unique
+    private static final int MAX_PAGE_COUNT = 100;
+
+    @WrapOperation(method = "<clinit>",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/network/codec/ByteBufCodecs;list()" +
+                    "Lnet/minecraft/network/codec/StreamCodec$CodecOperation;"))
+    private static <B extends ByteBuf, V> StreamCodec.CodecOperation<B, V, List<V>> clinit$list(
+            final Operation<StreamCodec.CodecOperation<B, V,List<V>>> original
+    ) {
+        return ByteBufCodecs.list(MAX_PAGE_COUNT);
+    }
+
+    @WrapOperation(method = "pagesCodec",
+            at = @At(value = "INVOKE",
+                    target = "Lcom/mojang/serialization/Codec;listOf()Lcom/mojang/serialization/Codec;"))
+    private static <A> Codec<List<A>> pagesCodec$listOf(final Codec<A> instance,
+                                                        final Operation<Codec<List<A>>> original) {
+
+        return instance.listOf(0, MAX_PAGE_COUNT);
+    }
+}

--- a/src/main/resources/kaboom-paper-mixins.mixins.json
+++ b/src/main/resources/kaboom-paper-mixins.mixins.json
@@ -29,6 +29,7 @@
     "fix.exploit.oversized_component.PacketMixin",
     "fix.exploit.oversized_component.ServerCommonPacketListenerImplMixin",
     "fix.exploit.oversized_component.Varint21LengthFieldPrependerMixin",
+    "fix.exploit.page_amount_exploit.WrittenBookContentMixin",
     "fix.exploit.projectile_huge_power.AbstractHurtingProjectileMixin",
     "fix.exploit.recursive_translate.TranslatableContentsMixin",
     "fix.exploit.uncapped_deathtime.LivingEntityMixin",


### PR DESCRIPTION
Prevents the server from throwing a StackOverflowError when someone gives themselves a book with a large amount of pages in a command.