### PR TITLE
fix: catch ReportedException before it's thrown in command blocks

### DIFF
--- a/src/main/java/pw/kaboom/papermixins/mixin/fix/exploit/cmd_block_uncaught_err/BaseCommandBlockMixin.java
+++ b/src/main/java/pw/kaboom/papermixins/mixin/fix/exploit/cmd_block_uncaught_err/BaseCommandBlockMixin.java
@@ -1,0 +1,32 @@
+package pw.kaboom.papermixins.mixin.fix.exploit.cmd_block_uncaught_err;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Cancellable;
+import net.minecraft.CrashReport;
+import net.minecraft.ReportedException;
+import net.minecraft.world.level.BaseCommandBlock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(BaseCommandBlock.class)
+public abstract class BaseCommandBlockMixin {
+    @SuppressWarnings("AddedMixinMembersNamePattern")
+    @Unique
+    private static final Logger LOGGER = LoggerFactory.getLogger("paper-mixins$cmd-block-uncaught-err");
+
+    @WrapOperation(method = "performCommand",
+            at = @At(value = "NEW", target = "(Lnet/minecraft/CrashReport;)Lnet/minecraft/ReportedException;"))
+        private ReportedException performCommand$throw(final CrashReport report,
+                                                       final Operation<ReportedException> original,
+                                                       @Cancellable final CallbackInfoReturnable<Boolean> ci) {
+        ci.cancel();
+        LOGGER.error("Caught exception in command block before throw", original.call(report));
+        return null;
+    }
+}

--- a/src/main/resources/kaboom-paper-mixins.mixins.json
+++ b/src/main/resources/kaboom-paper-mixins.mixins.json
@@ -23,6 +23,7 @@
     "fix.command_block_restrictions.FillCommandMixin",
     "fix.command_block_restrictions.StructureTemplateMixin",
     "fix.exploit.beehive_uncapped_bees.BeehiveBlockEntityOccupantMixin",
+    "fix.exploit.cmd_block_uncaught_err.BaseCommandBlockMixin",
     "fix.exploit.offhand_crash.ServerGamePacketListenerImplMixin",
     "fix.exploit.oversized_component.ClientboundBossEventPacketMixin",
     "fix.exploit.oversized_component.PacketMixin",


### PR DESCRIPTION
The server presents a crash report for only command blocks, but not for console commands or player commands. Interestingly, this behavior does not occur if you use one of the aliases in commands.yml (i.e. give over minecraft:give)